### PR TITLE
LrsDockWidget.resetLocateEvent(): Update for QGIS 3

### DIFF
--- a/lrs/ui/lrsdockwidget.py
+++ b/lrs/ui/lrsdockwidget.py
@@ -872,7 +872,8 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
             if point:
                 mapSettings = self.iface.mapCanvas().mapSettings()
                 if isProjectCrsEnabled() and getProjectCrs() != self.lrsLayer.crs:
-                    transform = QgsCoordinateTransform(self.lrsLayer.crs, mapSettings.destinationCrs())
+                    transform = QgsCoordinateTransform(self.lrsLayer.crs, mapSettings.destinationCrs(),
+                                                       QgsProject.instance())
                     point = transform.transform(point)
                 coordinates = "%.3f,%.3f" % (point.x(), point.y())
             else:


### PR DESCRIPTION
Set the transform context for the constructed QgsCoordinateTransform object using the project instance, to match the QGIS 3 API.

Fixes issue #28.