### PR TITLE
Create linear events of either directionality

### DIFF
--- a/lrs/lrs/lrsroutebase.py
+++ b/lrs/lrs/lrsroutebase.py
@@ -122,17 +122,17 @@ class LrsRouteBase(metaclass=ABCMeta):
             error = 'segment not available'
         else:
             # make error message  for gaps
-            measures.sort()
+            measures.sort(reverse=(start > end))
             # debug( '%s' % measures )
             for i in range(len(measures) - 1, 0, -1):
                 if doubleNear(measures[i][0], measures[i - 1][1]):
                     measures[i - 1][1] = measures[i][1]
                     del measures[i]
 
-            if start < measures[0][0]:
+            if ((start <= end) and (start < measures[0][0])) or ((start > end) and (start > measures[0][0])):
                 measures.insert(0, [start, start])
 
-            if end > measures[-1][1]:
+            if ((start <= end) and (end > measures[-1][1])) or ((start > end) and (end < measures[-1][1])):
                 measures.append([end, end])
 
             gaps = []
@@ -140,7 +140,7 @@ class LrsRouteBase(metaclass=ABCMeta):
             for i in range(len(measures) - 1):
                 measureFrom = measures[i][1]
                 measureTo = measures[i + 1][0]
-                if measureTo - measureFrom < tolerance:
+                if abs(measureTo - measureFrom) < tolerance:
                     continue
 
                 # measures are not formated (rounded) to show to user real data and dont hidden the true error by rounding


### PR DESCRIPTION
Add support for the creation of linear events that have a directionality opposite that of the route they reference; that is, linear events that have a "start" measure greater than their "end" measure.

Fixes issue #32.

- LrsLayerPart.eventSegments(): Canonicalize start and end measures to correctly detect overlap of requested segment.

- LrsLayerPart.linestringSegment(): Support extraction of line segment regardless of directionality.

- LrsRouteBase.eventMultiPolyLine(): Detect gaps and equivalent measures regardless of line-segment directionality.