### PR TITLE
LrsMeasures.calculate(): Update for QGIS 3

### DIFF
--- a/lrs/lrs/lrsmeasures.py
+++ b/lrs/lrs/lrsmeasures.py
@@ -67,7 +67,7 @@ class LrsMeasures(QObject):
         count = 0
         transform = None
         if layer.crs() != self.lrs.crs:
-            transform = QgsCoordinateTransform(layer.crs(), self.lrs.crs)
+            transform = QgsCoordinateTransform(layer.crs(), self.lrs.crs, QgsProject.instance())
         for feature in layer.getFeatures():
             points = []
 


### PR DESCRIPTION
Set the transform context for the constructed QgsCoordinateTransform object using the project instance, to match the QGIS 3 API.

Fixes issue #34.