### PR TITLE
Set tab order

### DIFF
--- a/lrs/ui/ui_lrsdockwidget.ui
+++ b/lrs/ui/ui_lrsdockwidget.ui
@@ -1205,6 +1205,61 @@
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>locateLrsLayerCombo</tabstop>
+  <tabstop>locateLrsRouteFieldCombo</tabstop>
+  <tabstop>locateRouteCombo</tabstop>
+  <tabstop>locateMeasureSpin</tabstop>
+  <tabstop>locateHighlightCheckBox</tabstop>
+  <tabstop>locateBufferSpin</tabstop>
+  <tabstop>locateHelpButton</tabstop>
+  <tabstop>locateCenterButton</tabstop>
+  <tabstop>locateZoomButton</tabstop>
+  <tabstop>eventsLrsLayerCombo</tabstop>
+  <tabstop>eventsLrsRouteFieldCombo</tabstop>
+  <tabstop>eventsLayerCombo</tabstop>
+  <tabstop>eventsRouteFieldCombo</tabstop>
+  <tabstop>eventsMeasureStartFieldCombo</tabstop>
+  <tabstop>eventsMeasureEndFieldCombo</tabstop>
+  <tabstop>eventsFeaturesSelectCombo</tabstop>
+  <tabstop>eventsOutputNameLineEdit</tabstop>
+  <tabstop>eventsErrorFieldLineEdit</tabstop>
+  <tabstop>measureLrsLayerCombo</tabstop>
+  <tabstop>measureLrsRouteFieldCombo</tabstop>
+  <tabstop>measureLayerCombo</tabstop>
+  <tabstop>measureThresholdSpin</tabstop>
+  <tabstop>measureOutputNameLineEdit</tabstop>
+  <tabstop>measureRouteFieldLineEdit</tabstop>
+  <tabstop>measureMeasureFieldLineEdit</tabstop>
+  <tabstop>calibTabWidget</tabstop>
+  <tabstop>genLineLayerCombo</tabstop>
+  <tabstop>genLineRouteFieldCombo</tabstop>
+  <tabstop>genPointLayerCombo</tabstop>
+  <tabstop>genPointRouteFieldCombo</tabstop>
+  <tabstop>genPointMeasureFieldCombo</tabstop>
+  <tabstop>genMeasureUnitCombo</tabstop>
+  <tabstop>genSelectionModeCombo</tabstop>
+  <tabstop>genSelectionLineEdit</tabstop>
+  <tabstop>genSelectionButton</tabstop>
+  <tabstop>genSnapSpin</tabstop>
+  <tabstop>genThresholdSpin</tabstop>
+  <tabstop>genParallelModeCombo</tabstop>
+  <tabstop>genExtrapolateCheckBox</tabstop>
+  <tabstop>genButtonBox</tabstop>
+  <tabstop>genOutputNameLineEdit</tabstop>
+  <tabstop>genCreateOutputButton</tabstop>
+  <tabstop>errorFilterLineEdit</tabstop>
+  <tabstop>errorView</tabstop>
+  <tabstop>errorButtonBox</tabstop>
+  <tabstop>errorZoomButton</tabstop>
+  <tabstop>addErrorLayersButton</tabstop>
+  <tabstop>addQualityLayerButton</tabstop>
+  <tabstop>helpTextBrowser</tabstop>
+  <tabstop>exportPostgisConnectionCombo</tabstop>
+  <tabstop>exportPostgisSchemaCombo</tabstop>
+  <tabstop>exportPostgisTableLineEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/lrs/ui/ui_lrsdockwidget.ui
+++ b/lrs/ui/ui_lrsdockwidget.ui
@@ -1053,6 +1053,9 @@
                 <layout class="QHBoxLayout" name="horizontalLayout_2">
                  <item>
                   <widget class="QDialogButtonBox" name="errorButtonBox">
+                   <property name="focusPolicy">
+                    <enum>Qt::StrongFocus</enum>
+                   </property>
                    <property name="standardButtons">
                     <set>QDialogButtonBox::Help</set>
                    </property>


### PR DESCRIPTION
Set the tab order among widgets in the dock-widget UI to allow easy navigation by keyboard. The order follows the conventional top-to-bottom, left-to-right motion.

This includes changing the focus policy of the "Help" button in the calibration-errors tab so it can receive focus and participate in the tab order.

Fixes issue #38.