### PR TITLE
fixFields(): Preserve 64-bit integer fields

### DIFF
--- a/lrs/lrs/utils.py
+++ b/lrs/lrs/utils.py
@@ -282,9 +282,9 @@ def fixFields(fieldsList):
         elif field.type() == QVariant.Int:
             field.setTypeName('int')
         elif field.type() == QVariant.LongLong:
-            field.setTypeName('int')
+            field.setTypeName('int8')
         elif field.type() == QVariant.ULongLong:
-            field.setTypeName('int')
+            field.setTypeName('int8')
         elif field.type() == QVariant.Double:
             field.setTypeName('double')
 


### PR DESCRIPTION
Map 64-bit integer fields to the equivalent "int8" type recognized by the memory data provider.

Fixes issue #40.