### PR TITLE
Measures: Use route specified by feature

### DIFF
--- a/lrs/lrs/lrsmeasures.py
+++ b/lrs/lrs/lrsmeasures.py
@@ -32,7 +32,7 @@ class LrsMeasures(QObject):
         self.lrs = lrs  # Lrs object
         self.progressBar = progressBar
 
-    def calculate(self, layer, routeFieldName, measureFieldName, threshold, outputName):
+    def calculate(self, layer, outputRouteFieldName, measureFieldName, threshold, outputName):
         # get the  lrs layer's route field, to obtain its type
         lrsFields = self.lrs.layer.fields()
         lrsRouteField = lrsFields.at(lrsFields.indexFromName(self.lrs.routeFieldName))
@@ -46,7 +46,7 @@ class LrsMeasures(QObject):
         fixFields(fieldsList)
         provider.addAttributes(fieldsList)
         provider.addAttributes([
-            QgsField(routeFieldName, lrsRouteField.type(), lrsRouteField.typeName()),
+            QgsField(outputRouteFieldName, lrsRouteField.type(), lrsRouteField.typeName()),
             QgsField(measureFieldName, QVariant.Double, "double"),
         ])
 
@@ -61,7 +61,7 @@ class LrsMeasures(QObject):
         #     if not outputLayer.addAttribute(field):
         #         QMess        # create new layerageBox.information(self, 'Information', 'Cannot add attribute %s' % field.name())
         #
-        # outputLayer.addAttribute(QgsField(routeFieldName, QVariant.String, "string"))
+        # outputLayer.addAttribute(QgsField(outputRouteFieldName, QVariant.String, "string"))
         # outputLayer.addAttribute(QgsField(measureFieldName, QVariant.Double, "double"))
         # outputLayer.commitChanges()
 
@@ -96,7 +96,7 @@ class LrsMeasures(QObject):
                 # debug ( "routeId = %s merasure = %s" % (routeId, measure) )
 
                 if routeId is not None:
-                    outputFeature[routeFieldName] = routeId
+                    outputFeature[outputRouteFieldName] = routeId
                 outputFeature[measureFieldName] = measure
 
                 outputFeatures.append(outputFeature)

--- a/lrs/lrs/lrspartbase.py
+++ b/lrs/lrs/lrspartbase.py
@@ -75,6 +75,10 @@ class LrsPartBase(metaclass=ABCMeta):
     def eventSegments(self, start, end):
         pass
 
+    # get the minimum distance between this part and another geometry
+    def distance(self, geometry):
+        return self.polylineGeo.distance(geometry)
+
     # get measure for nearest point on polyline
     # returns None if there is no record for the nearest point
     @abstractmethod

--- a/lrs/lrs/lrsroutebase.py
+++ b/lrs/lrs/lrsroutebase.py
@@ -22,6 +22,8 @@
 import sys
 from abc import ABCMeta, abstractmethod
 
+from qgis.core import QgsGeometry
+
 from .error.lrserror import LrsError
 from .utils import LrsUnits, formatMeasure, doubleNear, debug
 
@@ -153,4 +155,11 @@ class LrsRouteBase(metaclass=ABCMeta):
         # debug( '%s' % measures )
         return multipolyline, error
 
+    # get measure for nearest point along any part
+    def pointMeasure(self, point):
+        # locate the part nearest to the point
+        pointGeometry = QgsGeometry.fromPointXY(point)
+        nearestPart = min(self.parts, key=lambda part: part.distance(pointGeometry))
 
+        # return the measure along this part
+        return nearestPart.pointMeasure(point)

--- a/lrs/ui/lrsdockwidget.py
+++ b/lrs/ui/lrsdockwidget.py
@@ -157,6 +157,8 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         # ----------------------- measureTab ---------------------------
         self.measureLayerCM = LrsLayerComboManager(self.measureLayerCombo, geometryType=QgsWkbTypes.PointGeometry,
                                                    settingsName='measureLayerId')
+        self.measureRouteFieldCM = LrsFieldComboManager(self.measureRouteFieldCombo, self.measureLayerCM,
+                                                        allowNone=True, settingsName='measureRouteField')
         self.measureThresholdWM = LrsWidgetManager(self.measureThresholdSpin, settingsName='measureThreshold',
                                                    defaultValue=100.0)
         self.measureOutputNameWM = LrsWidgetManager(self.measureOutputNameLineEdit, settingsName='measureOutputName',
@@ -970,6 +972,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
     def resetMeasureOptions(self):
         # #debug('resetMeasureOptions')
         self.measureLayerCM.reset()
+        self.measureRouteFieldCM.reset()
         self.measureThresholdWM.reset()
         self.measureOutputNameWM.reset()
         self.measureOutputRouteFieldWM.reset()
@@ -992,6 +995,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
     # save settings in project
     def writeMeasureOptions(self):
         self.measureLayerCM.writeToProject()
+        self.measureRouteFieldCM.writeToProject()
         self.measureThresholdWM.writeToProject()
         self.measureOutputNameWM.writeToProject()
         self.measureOutputRouteFieldWM.writeToProject()
@@ -999,6 +1003,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
 
     def readMeasureOptions(self):
         self.measureLayerCM.readFromProject()
+        self.measureRouteFieldCM.readFromProject()
         self.measureThresholdWM.readFromProject()
         self.measureOutputNameWM.readFromProject()
         self.measureOutputRouteFieldWM.readFromProject()
@@ -1018,6 +1023,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         self.measureProgressBar.show()
 
         layer = self.measureLayerCM.getLayer()
+        routeFieldName = self.measureRouteFieldCM.getFieldName()
         threshold = self.measureThresholdSpin.value()
         outputName = self.measureOutputNameLineEdit.text()
         if not outputName: outputName = self.measureOutputNameWM.defaultValue()
@@ -1025,7 +1031,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         measureFieldName = self.measureMeasureFieldLineEdit.text()
 
         measures = LrsMeasures(self.iface, self.lrsLayer, self.measureProgressBar)
-        measures.calculate(layer, outputRouteFieldName, measureFieldName, threshold, outputName)
+        measures.calculate(layer, routeFieldName, outputRouteFieldName, measureFieldName, threshold, outputName)
 
     # ------------------- STATS -------------------
 

--- a/lrs/ui/lrsdockwidget.py
+++ b/lrs/ui/lrsdockwidget.py
@@ -162,10 +162,11 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         self.measureOutputNameWM = LrsWidgetManager(self.measureOutputNameLineEdit, settingsName='measureOutputName',
                                                     defaultValue='LRS measure')
 
-        self.measureRouteFieldWM = LrsWidgetManager(self.measureRouteFieldLineEdit, settingsName='measureRouteField',
-                                                    defaultValue='route')
+        self.measureOutputRouteFieldWM = LrsWidgetManager(self.measureOutputRouteFieldLineEdit,
+                                                          settingsName='measureOutputRouteField',
+                                                          defaultValue='route')
         validator = QRegExpValidator(QRegExp('[A-Za-z_][A-Za-z0-9_]+'), None)
-        self.measureRouteFieldLineEdit.setValidator(validator)
+        self.measureOutputRouteFieldLineEdit.setValidator(validator)
 
         self.measureMeasureFieldWM = LrsWidgetManager(self.measureMeasureFieldLineEdit,
                                                       settingsName='measureMeasureField', defaultValue='measure')
@@ -176,7 +177,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         self.measureButtonBox.button(QDialogButtonBox.Help).clicked.connect(lambda: self.showHelp('measures'))
         self.measureLayerCombo.currentIndexChanged.connect(self.resetMeasureButtons)
         self.measureOutputNameLineEdit.textEdited.connect(self.resetMeasureButtons)
-        self.measureRouteFieldLineEdit.textEdited.connect(self.resetMeasureButtons)
+        self.measureOutputRouteFieldLineEdit.textEdited.connect(self.resetMeasureButtons)
         self.measureMeasureFieldLineEdit.textEdited.connect(self.resetMeasureButtons)
         self.resetMeasureOptions()
         self.resetMeasureButtons()
@@ -971,7 +972,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         self.measureLayerCM.reset()
         self.measureThresholdWM.reset()
         self.measureOutputNameWM.reset()
-        self.measureRouteFieldWM.reset()
+        self.measureOutputRouteFieldWM.reset()
         self.measureMeasureFieldWM.reset()
 
         self.resetMeasureButtons()
@@ -983,7 +984,7 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
     def resetMeasureButtons(self):
         # #debug('resetMeasureButtons')
         enabled = bool(self.lrsLayer) and self.measureLayerCombo.currentIndex() != -1 and bool(
-            self.measureOutputNameLineEdit.text()) and bool(self.measureRouteFieldLineEdit.text()) and bool(
+            self.measureOutputNameLineEdit.text()) and bool(self.measureOutputRouteFieldLineEdit.text()) and bool(
             self.measureMeasureFieldLineEdit.text())
 
         self.measureButtonBox.button(QDialogButtonBox.Ok).setEnabled(enabled)
@@ -993,14 +994,14 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         self.measureLayerCM.writeToProject()
         self.measureThresholdWM.writeToProject()
         self.measureOutputNameWM.writeToProject()
-        self.measureRouteFieldWM.writeToProject()
+        self.measureOutputRouteFieldWM.writeToProject()
         self.measureMeasureFieldWM.writeToProject()
 
     def readMeasureOptions(self):
         self.measureLayerCM.readFromProject()
         self.measureThresholdWM.readFromProject()
         self.measureOutputNameWM.readFromProject()
-        self.measureRouteFieldWM.readFromProject()
+        self.measureOutputRouteFieldWM.readFromProject()
         self.measureMeasureFieldWM.readFromProject()
 
     # set threshold units according to current crs
@@ -1020,11 +1021,11 @@ class LrsDockWidget(QDockWidget, Ui_LrsDockWidget):
         threshold = self.measureThresholdSpin.value()
         outputName = self.measureOutputNameLineEdit.text()
         if not outputName: outputName = self.measureOutputNameWM.defaultValue()
-        routeFieldName = self.measureRouteFieldLineEdit.text()
+        outputRouteFieldName = self.measureOutputRouteFieldLineEdit.text()
         measureFieldName = self.measureMeasureFieldLineEdit.text()
 
         measures = LrsMeasures(self.iface, self.lrsLayer, self.measureProgressBar)
-        measures.calculate(layer, routeFieldName, measureFieldName, threshold, outputName)
+        measures.calculate(layer, outputRouteFieldName, measureFieldName, threshold, outputName)
 
     # ------------------- STATS -------------------
 

--- a/lrs/ui/ui_lrsdockwidget.ui
+++ b/lrs/ui/ui_lrsdockwidget.ui
@@ -413,35 +413,35 @@
             </property>
            </widget>
           </item>
-          <item row="12" column="0">
+          <item row="13" column="0">
            <widget class="QLabel" name="measureOutputNameLabel">
             <property name="text">
              <string>Output layer name</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="0" colspan="2">
+          <item row="12" column="0" colspan="2">
            <widget class="Line" name="line_4">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="13" column="0">
+          <item row="14" column="0">
            <widget class="QLabel" name="measureOutputRouteFieldLabel">
             <property name="text">
              <string>Output route field</string>
             </property>
            </widget>
           </item>
-          <item row="14" column="0">
+          <item row="15" column="0">
            <widget class="QLabel" name="measureMeasureFieldLabel">
             <property name="text">
              <string>Output measure field</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+          <item row="10" column="0">
            <widget class="QLabel" name="measureThresholdLabel">
             <property name="toolTip">
              <string>Maximum distance of point from line.</string>
@@ -458,7 +458,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="2">
+          <item row="9" column="0" colspan="2">
            <widget class="Line" name="line_5">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -479,28 +479,28 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="1">
+          <item row="15" column="1">
            <widget class="QLineEdit" name="measureMeasureFieldLineEdit">
             <property name="text">
              <string/>
             </property>
            </widget>
           </item>
-          <item row="13" column="1">
+          <item row="14" column="1">
            <widget class="QLineEdit" name="measureOutputRouteFieldLineEdit">
             <property name="text">
              <string/>
             </property>
            </widget>
           </item>
-          <item row="12" column="1">
+          <item row="13" column="1">
            <widget class="QLineEdit" name="measureOutputNameLineEdit">
             <property name="text">
              <string/>
             </property>
            </widget>
           </item>
-          <item row="9" column="1">
+          <item row="10" column="1">
            <widget class="QDoubleSpinBox" name="measureThresholdSpin">
             <property name="toolTip">
              <string>Maximum distance of point from line.</string>
@@ -524,6 +524,16 @@
           </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="measureLrsLayerCombo"/>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="measureRouteFieldLabel">
+            <property name="text">
+             <string>Route field</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QComboBox" name="measureRouteFieldCombo"/>
           </item>
          </layout>
         </item>
@@ -1167,6 +1177,7 @@
   <tabstop>measureLrsLayerCombo</tabstop>
   <tabstop>measureLrsRouteFieldCombo</tabstop>
   <tabstop>measureLayerCombo</tabstop>
+  <tabstop>measureRouteFieldCombo</tabstop>
   <tabstop>measureThresholdSpin</tabstop>
   <tabstop>measureOutputNameLineEdit</tabstop>
   <tabstop>measureOutputRouteFieldLineEdit</tabstop>

--- a/lrs/ui/ui_lrsdockwidget.ui
+++ b/lrs/ui/ui_lrsdockwidget.ui
@@ -428,7 +428,7 @@
            </widget>
           </item>
           <item row="13" column="0">
-           <widget class="QLabel" name="measureRouteFieldLabel">
+           <widget class="QLabel" name="measureOutputRouteFieldLabel">
             <property name="text">
              <string>Output route field</string>
             </property>
@@ -487,7 +487,7 @@
            </widget>
           </item>
           <item row="13" column="1">
-           <widget class="QLineEdit" name="measureRouteFieldLineEdit">
+           <widget class="QLineEdit" name="measureOutputRouteFieldLineEdit">
             <property name="text">
              <string/>
             </property>
@@ -1169,7 +1169,7 @@
   <tabstop>measureLayerCombo</tabstop>
   <tabstop>measureThresholdSpin</tabstop>
   <tabstop>measureOutputNameLineEdit</tabstop>
-  <tabstop>measureRouteFieldLineEdit</tabstop>
+  <tabstop>measureOutputRouteFieldLineEdit</tabstop>
   <tabstop>measureMeasureFieldLineEdit</tabstop>
   <tabstop>calibTabWidget</tabstop>
   <tabstop>genLineLayerCombo</tabstop>


### PR DESCRIPTION
These changes extend the measurements-generating functionality of the plugin by allowing the user to select a field in the input layer specifying a route-ID value that, when present and valid, will be used to select the route against which to generate a measurement for the feature, overriding the default behaviour of automatically selecting a nearby route.

This provides the enhancement requested in issue #42.

Specifically, these changes

- Add a new control, "Route field", to the "Measures" tab of the plugin that allows the user to select an input-layer field that holds route-ID values.

- Adds a new method, `distance()`, to `LrsPartBase` that returns the minimum distance between the part and another geometry (i.e. a point).

- Adds a new method, `pointMeasure()`, to `LrsRouteBase` that accepts a point and returns the measurement of the nearest point along any of the route's parts.

- Modifies `LrsMeasure.calculate()` so it
    - Accepts an additional parameter, `routeFieldName`, that optionally specifies the name of an input-layer field that holds a route-ID value (the existing `routeFieldName` parameter having been renamed to `outputRouteFieldName`); and

    - Honours the route, if any, specified by a feature when calculating a measurement for it.

Note that

- Leaving the "Route field" control at its default (unspecified) setting preserves the plugin's existing behaviour: A route is selected automatically for each feature based on proximity.

- If the user _does_ select a route-ID field, then for each feature in the input layer

    - If the value of the field is NULL, the default behaviour is used: A nearby route is selected automatically.

    - If the value of the field specifies an invalid route, no measurement is generated (the default behaviour is suppressed).

- The "measureRouteField" project setting was previously used for the value of the _output_ route-ID field; users opening existing projects will need to set the "Route field" and "Output route field" controls appropriately and re-save the project. However, this will need to be done only once.

- `LrsPartBase.distance()` is implemented directly in the base class. This seems reasonable based on the implementation of its subclasses, `LrsLayerPart` and `LrsCalibPart`, but **you may want to review this and advise**.
