### PR TITLE
LrsCalib.__init__(): Update for QGIS 3

### DIFF
--- a/lrs/lrs/lrscalib.py
+++ b/lrs/lrs/lrscalib.py
@@ -129,11 +129,13 @@ class LrsCalib(LrsBase):
 
         self.lineTransform = None
         if self.crs and self.crs != lineLayer.crs():
-            self.lineTransform = QgsCoordinateTransform(lineLayer.crs(), self.crs)
+            self.lineTransform = QgsCoordinateTransform(lineLayer.crs(), self.crs,
+                                                        QgsProject.instance())
 
         self.pointTransform = None
         if self.crs and self.crs != pointLayer.crs():
-            self.pointTransform = QgsCoordinateTransform(pointLayer.crs(), self.crs)
+            self.pointTransform = QgsCoordinateTransform(pointLayer.crs(), self.crs,
+                                                         QgsProject.instance())
 
         self.wasEdited = False  # true if layers were edited since calibration
 


### PR DESCRIPTION
This change update `LrsCalib.__init__()` to match the QGIS 3 API, fixing a crash when the "OK" button on the "Calibration" tab is clicked (reported in #45).